### PR TITLE
Fixed for new errorformat (after nightly 2016/08/10)

### DIFF
--- a/syntax_checkers/rust/cargo.vim
+++ b/syntax_checkers/rust/cargo.vim
@@ -39,6 +39,7 @@ function! SyntaxCheckers_rust_cargo_GetLocList() dict
                 \ '%-G,' .
                 \ '%-Gerror: aborting %.%#,' .
                 \ '%-Gerror: Could not compile %.%#,' .
+                \ '%-Gwarning: the option %.%#,' .
                 \ '%Eerror: %m,' .
                 \ '%Eerror[E%n]: %m,' .
                 \ '%Wwarning: %m,' .

--- a/syntax_checkers/rust/cargo.vim
+++ b/syntax_checkers/rust/cargo.vim
@@ -31,8 +31,23 @@ function! SyntaxCheckers_rust_cargo_GetLocList() dict
 	let errorformat  =
 				\ '%E%f:%l:%c: %\d%#:%\d%# %.%\{-}error:%.%\{-} %m,'   .
 				\ '%W%f:%l:%c: %\d%#:%\d%# %.%\{-}warning:%.%\{-} %m,' .
-				\ '%C%f:%l %m,' .
-				\ '%-Z%.%#'
+				\ '%C%f:%l %m'
+
+    " New errorformat (after nightly 2016/08/10)
+    let errorformat  .=
+                \ ',' .
+                \ '%-G,' .
+                \ '%-Gerror: aborting %.%#,' .
+                \ '%-Gerror: Could not compile %.%#,' .
+                \ '%Eerror: %m,' .
+                \ '%Eerror[E%n]: %m,' .
+                \ '%Wwarning: %m,' .
+                \ '%Inote: %m,' .
+                \ '%C %#--> %f:%l:%c'
+
+    let errorformat  .=
+                \ ',' .
+                \ '%-Z%.%#'
 
 	return SyntasticMake({
 				\ 'makeprg': makeprg,

--- a/syntax_checkers/rust/cargo.vim
+++ b/syntax_checkers/rust/cargo.vim
@@ -6,7 +6,7 @@
 " https://github.com/scrooloose/syntastic/wiki/Syntax-Checker-Guide#external
 
 if exists("g:loaded_syntastic_rust_cargo_checker")
-	finish
+    finish
 endif
 let g:loaded_syntastic_rust_cargo_checker = 1
 
@@ -14,24 +14,24 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_rust_cargo_IsAvailable() dict
-	return executable(self.getExec())
+    return executable(self.getExec())
 endfunction
 
 if exists('g:syntastic_extra_filetypes')
-	call add(g:syntastic_extra_filetypes, 'rust')
+    call add(g:syntastic_extra_filetypes, 'rust')
 else
-	let g:syntastic_extra_filetypes = ['rust']
+    let g:syntastic_extra_filetypes = ['rust']
 endif
 
 function! SyntaxCheckers_rust_cargo_GetLocList() dict
-	let makeprg = self.makeprgBuild({
-				\ 'args': 'rustc -Zno-trans',
-				\ 'fname': '' })
+    let makeprg = self.makeprgBuild({
+                \ 'args': 'check',
+                \ 'fname': '' })
 
-	let errorformat  =
-				\ '%E%f:%l:%c: %\d%#:%\d%# %.%\{-}error:%.%\{-} %m,'   .
-				\ '%W%f:%l:%c: %\d%#:%\d%# %.%\{-}warning:%.%\{-} %m,' .
-				\ '%C%f:%l %m'
+    let errorformat  =
+                \ '%E%f:%l:%c: %\d%#:%\d%# %.%\{-}error:%.%\{-} %m,'   .
+                \ '%W%f:%l:%c: %\d%#:%\d%# %.%\{-}warning:%.%\{-} %m,' .
+                \ '%C%f:%l %m'
 
     " New errorformat (after nightly 2016/08/10)
     let errorformat  .=
@@ -50,14 +50,15 @@ function! SyntaxCheckers_rust_cargo_GetLocList() dict
                 \ ',' .
                 \ '%-Z%.%#'
 
-	return SyntasticMake({
-				\ 'makeprg': makeprg,
-				\ 'errorformat': errorformat })
+    return SyntasticMake({
+                \ 'makeprg': makeprg,
+                \ 'errorformat': errorformat,
+                \ 'enable': 'enable_cargo_checker'})
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
-			\ 'filetype': 'rust',
-			\ 'name': 'cargo'})
+            \ 'filetype': 'rust',
+            \ 'name': 'cargo'})
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
There is some further trouble brewing though:

cargo currently warns:
warning: the option `Z` is unstable and should only be used on the nightly compiler, but it is currently accepted for backwards compatibility; this will soon change, see issue #31847 for more details

https://github.com/rust-lang/rust/issues/31847

Works for now on stable though.
